### PR TITLE
⬇️ Upper bound scipy for compatibility with fcsparser

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
       - name: Checkout main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ readme = "README.md"
 dynamic = ["version", "description"]
 classifiers = [
     "License :: OSI Approved :: Apache Software License",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dependencies = [
     "lamin_utils",
     "fcsparser",
-    "numpy<2.0.0", # for compatibility with fcsparser
+    "scipy<1.13.0rc1", # for compatibility with fcsparser
     "anndata",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,9 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
+    "scipy<1.13.0rc1", # for compatibility with fcsparser
     "lamin_utils",
     "fcsparser",
-    "scipy<1.13.0rc1", # for compatibility with fcsparser
     "anndata",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
 dependencies = [
     "lamin_utils",
     "fcsparser",
+    "numpy<2.0.0", # for compatibility with fcsparser
     "anndata",
 ]
 


### PR DESCRIPTION
scipy>=1.13 requires numpy>=2.0.0 which is incompatible with fcsparser. Better to pin scipy here to avoid incompatibilities between scipy and numpy.