### PR TITLE
✨ Use `FlowIO` instead of `fcsparser`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
           fetch-depth: 0
       - name: Checkout lndocs
         uses: actions/checkout@v3
+        if: matrix.python-version == '3.12'
         with:
           repository: laminlabs/lndocs
           ssh-key: ${{ secrets.READ_LNDOCS }}
@@ -34,6 +35,7 @@ jobs:
           cache-dependency-path: ".github/workflows/build.yml" # See dependencies below
       - name: Cache pre-commit
         uses: actions/cache@v3
+        if: matrix.python-version == '3.12'
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
@@ -51,6 +53,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
       - uses: cloudflare/pages-action@v1
         id: cloudflare
+        if: matrix.python-version == '3.12'
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: 472bdad691b4483dea759eadb37110bd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - name: Checkout main
@@ -42,10 +42,10 @@ jobs:
           python -m pip install -U pip
           pip install -U laminci
       - run: nox -s lint
-        if: matrix.python-version == '3.9'
+        if: matrix.python-version == '3.12'
       - run: nox -s build
       - name: Codecov
-        if: matrix.python-version == '3.9'
+        if: matrix.python-version == '3.12'
         uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,6 @@ jobs:
           fetch-depth: 0
       - name: Checkout lndocs
         uses: actions/checkout@v3
-        if: matrix.python-version == '3.12'
         with:
           repository: laminlabs/lndocs
           ssh-key: ${{ secrets.READ_LNDOCS }}

--- a/docs/quickstart.ipynb
+++ b/docs/quickstart.ipynb
@@ -184,6 +184,42 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d1b8b690",
+   "metadata": {},
+   "source": [
+    "Channels."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d3136754",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fcsfile.channels"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2cca65aa",
+   "metadata": {},
+   "source": [
+    "Header."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bf9583be",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fcsfile.header"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "03ba7e77",
    "metadata": {},
    "source": [

--- a/docs/quickstart.ipynb
+++ b/docs/quickstart.ipynb
@@ -168,9 +168,7 @@
    "id": "bf99a9a5",
    "metadata": {},
    "source": [
-    "Metadata is stored as a dict in `.meta`\n",
-    "\n",
-    "This equals to `adata.uns['meta']`"
+    "Metadata is stored as a dict in `.meta`, note all keys are lower cased and without the starting `$`."
    ]
   },
   {
@@ -180,7 +178,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fcsfile.meta.get(\"$CYT\")"
+    "# cytometer\n",
+    "fcsfile.meta.get(\"cyt\")"
    ]
   },
   {
@@ -263,11 +262,8 @@
   }
  ],
  "metadata": {
-  "interpreter": {
-   "hash": "ae1fefc8646a06dd2e75004cd934adda7c5727b046986a772e3b44b0ffba9754"
-  },
   "kernelspec": {
-   "display_name": "Python 3.9.7 ('py39')",
+   "display_name": "py310",
    "language": "python",
    "name": "python3"
   },
@@ -281,7 +277,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,8 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-    "scipy<1.13.0rc1", # for compatibility with fcsparser
     "lamin_utils",
-    "fcsparser",
+    "flowio",
     "anndata",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,13 +9,13 @@ readme = "README.md"
 dynamic = ["version", "description"]
 classifiers = [
     "License :: OSI Approved :: Apache Software License",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "lamin_utils",
     "flowio",
     "anndata",
 ]

--- a/readfcs/_core.py
+++ b/readfcs/_core.py
@@ -94,10 +94,7 @@ class ReadFCS:
     """
 
     def __init__(self, filepath: Union[str, Path], data_set: int = 0) -> None:
-        # No metadata formating using fcsparser
-        # self._meta_raw, self._data = fcsparser.parse(
-        #     filepath, data_set=data_set, channel_naming="$PnN"
-        # )
+        # FlowIO makes all keys lowercase in .text
         self._flow_data = flowio.FlowData(filepath)
 
         # data
@@ -171,7 +168,8 @@ class ReadFCS:
         """Convert the FCSFile instance to an AnnData.
 
         Args:
-            reindex: variables will be reindexed with marker names if possible otherwise
+            reindex: bool. Default is True
+                variables will be reindexed with marker names if possible otherwise
                 channels
         Returns:
             an AnnData object
@@ -244,9 +242,8 @@ def read(filepath, reindex=True) -> ad.AnnData:
     Args:
         filepath: str or Path
             location of fcs file to parse
-        reindex: bool
-            variables will be reindexed with marker names if possible otherwise
-            channels
+        reindex: bool. Default is True
+            variables will be reindexed with marker names if possible otherwise channels
     Returns:
         an AnnData object
     """

--- a/readfcs/_core.py
+++ b/readfcs/_core.py
@@ -89,18 +89,13 @@ class ReadFCS:
     Args:
         filepath: str or Path
             location of fcs file to parse
-        data_set: int or None. Default is None
+        data_set: int. Default is 0.
             Index of retrieved data set in the fcs file.
     """
 
-    def __init__(
-        self, filepath: Union[str, Path], data_set: Union[int, None] = None
-    ) -> None:
+    def __init__(self, filepath: Union[str, Path], data_set: int = 0) -> None:
         # FlowIO makes all keys lowercase in .text
-        if data_set is not None:
-            self._flow_data = flowio.read_multiple_data_sets()[data_set]
-        else:
-            self._flow_data = flowio.FlowData(filepath)
+        self._flow_data = flowio.read_multiple_data_sets(filepath)[data_set]
 
         # data
         self._data = pd.DataFrame(
@@ -256,13 +251,13 @@ def read(filepath, reindex=True) -> ad.AnnData:
     return fcsfile.to_anndata(reindex=reindex)
 
 
-def view(filepath: Union[str, Path], data_set: Union[int, None] = None) -> tuple:
+def view(filepath: Union[str, Path], data_set: int = 0) -> tuple:
     """Read in file content without preprocessing for debugging.
 
     Args:
         filepath: str or Path
             location of fcs file to parse
-        data_set: int or None. Default is None
+        data_set: int. Default is 0.
             Index of retrieved data set in the fcs file.
 
     Returns:
@@ -273,10 +268,7 @@ def view(filepath: Union[str, Path], data_set: Union[int, None] = None) -> tuple
     See `flowio.FlowData`:
         https://flowio.readthedocs.io/en/latest/api.html#flowio.FlowData
     """
-    if data_set is not None:
-        flow_data = flowio.read_multiple_data_sets(filepath)[data_set]
-    else:
-        flow_data = flowio.FlowData(filepath)
+    flow_data = flowio.read_multiple_data_sets(filepath)[data_set]
 
     # data
     data = np.reshape(flow_data.events, (-1, flow_data.channel_count))

--- a/readfcs/_core.py
+++ b/readfcs/_core.py
@@ -93,7 +93,9 @@ class ReadFCS:
             Index of retrieved data set in the fcs file.
     """
 
-    def __init__(self, filepath: Union[str, Path], data_set: int | None = None) -> None:
+    def __init__(
+        self, filepath: Union[str, Path], data_set: Union[int, None] = None
+    ) -> None:
         # FlowIO makes all keys lowercase in .text
         if data_set is not None:
             self._flow_data = flowio.read_multiple_data_sets()[data_set]
@@ -128,7 +130,7 @@ class ReadFCS:
     @property
     def header(self) -> dict:
         """Header."""
-        return self._meta["header"]
+        return self._header
 
     @property
     def channels(self) -> pd.DataFrame:
@@ -254,7 +256,7 @@ def read(filepath, reindex=True) -> ad.AnnData:
     return fcsfile.to_anndata(reindex=reindex)
 
 
-def view(filepath: Union[str, Path], data_set: int | None = None) -> tuple:
+def view(filepath: Union[str, Path], data_set: Union[int, None] = None) -> tuple:
     """Read in file content without preprocessing for debugging.
 
     Args:


### PR DESCRIPTION
- `FlowIO` only parses `PnN` and `PnS`, so we kept the previous custom code to parse all the `PnX` channels into `.channels`
- Extend CI to run on py3.9 - py3.13